### PR TITLE
Fix(dp): fix wordBreak solution in dp

### DIFF
--- a/basic_algorithm/dp.md
+++ b/basic_algorithm/dp.md
@@ -488,7 +488,11 @@ func wordBreak(s string, wordDict []string) bool {
 	f[0] = true
 	max := maxLen(wordDict)
 	for i := 1; i <= len(s); i++ {
-		for j := i - max; j < i && j >= 0; j++ {
+		l := 0
+		if i - max > 0 {
+			l = i - max
+		}
+		for j := l; j < i; j++ {
 			if f[j] && inDict(s[j:i]) {
 				f[i] = true
 				break


### PR DESCRIPTION
源解法在遇到输入
```
"bb"
["a","b","bbb","bbbb"]
```
时，会输出错误结果

修正后 LeetCode 双 100
```
执行结果：
通过
显示详情
执行用时：
0 ms
, 在所有 Go 提交中击败了
100.00%
的用户
内存消耗：
2.2 MB
, 在所有 Go 提交中击败了
100.00%
的用户
```